### PR TITLE
re-organize top level checks to add an 'all' command

### DIFF
--- a/cmd/allInfo.go
+++ b/cmd/allInfo.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"github.com/raesene/eathar/pkg/eathar"
+	"github.com/spf13/cobra"
+)
+
+// allInfoCmd represents the allInfo command
+var allInfoCmd = &cobra.Command{
+	Use:   "all",
+	Short: "Runs all the info checks",
+	Long:  `Runs all the checks in the info group.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		options := cmd.Flags()
+		imageListSlice := eathar.ImageList(options)
+		eathar.ReportImage(imageListSlice, options, "Image List")
+	},
+}
+
+func init() {
+	infoCmd.AddCommand(allInfoCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// allInfoCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// allInfoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/allPSS.go
+++ b/cmd/allPSS.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"github.com/raesene/eathar/pkg/eathar"
+	"github.com/spf13/cobra"
+)
+
+// allPSSCmd represents the allPSS command
+var allPSSCmd = &cobra.Command{
+	Use:   "all",
+	Short: "Runs all the PSS commands",
+	Long:  `Runs all the checks in the PSS group.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		options := cmd.Flags()
+		allowprivesccont := eathar.AllowPrivEsc(options)
+		eathar.ReportPSS(allowprivesccont, options, "Allow Privilege Escalation")
+		apparmor := eathar.Apparmor(options)
+		eathar.ReportPSS(apparmor, options, "Apparmor Disabled")
+		capadded := eathar.AddedCapabilities(options)
+		eathar.ReportPSS(capadded, options, "Added Capabilities")
+		capdropped := eathar.DroppedCapabilities(options)
+		eathar.ReportPSS(capdropped, options, "Dropped Capabilities")
+		hostipccont := eathar.Hostipc(options)
+		eathar.ReportPSS(hostipccont, options, "Host IPC")
+		hostnetcont := eathar.Hostnet(options)
+		eathar.ReportPSS(hostnetcont, options, "Host Network")
+		hostpath := eathar.HostPath(options)
+		eathar.ReportPSS(hostpath, options, "Host Path")
+		hostpidcont := eathar.Hostpid(options)
+		eathar.ReportPSS(hostpidcont, options, "Host PID")
+		hostports := eathar.HostPorts(options)
+		eathar.ReportPSS(hostports, options, "Host Ports")
+		hostprocesscont := eathar.HostProcess(options)
+		eathar.ReportPSS(hostprocesscont, options, "Host Process")
+		privcont := eathar.Privileged(options)
+		eathar.ReportPSS(privcont, options, "Privileged Container")
+		seccomp := eathar.Seccomp(options)
+		eathar.ReportPSS(seccomp, options, "Seccomp Disabled")
+		unmaskedproc := eathar.Procmount(options)
+		eathar.ReportPSS(unmaskedproc, options, "Unmasked Procmount")
+		sysctls := eathar.Sysctl(options)
+		eathar.ReportPSS(sysctls, options, "Unsafe Sysctl")
+	},
+}
+
+func init() {
+	pssCmd.AddCommand(allPSSCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// allPSSCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// allPSSCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/allRBAC.go
+++ b/cmd/allRBAC.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"github.com/raesene/eathar/pkg/eathar"
+	"github.com/spf13/cobra"
+)
+
+// allRBACCmd represents the allRBAC command
+var allRBACCmd = &cobra.Command{
+	Use:   "all",
+	Short: "Runs all the RBAC commands",
+	Long:  `Runs all the RBAC commands`,
+	Run: func(cmd *cobra.Command, args []string) {
+		options := cmd.Flags()
+		clusterAdminRoleBindingList := eathar.GetClusterAdminUsers(options)
+		eathar.ReportRBAC(clusterAdminRoleBindingList, options, "Cluster Admin Users")
+		getSecretsUsersList := eathar.GetSecretsUsers(options)
+		eathar.ReportRBAC(getSecretsUsersList, options, "Users with access to secrets")
+		createPVUsersList := eathar.CreatePVUsers(options)
+		eathar.ReportRBAC(createPVUsersList, options, "Users with access to create persistent volumes")
+		impersonateUsersList := eathar.ImpersonateUsers(options)
+		eathar.ReportRBAC(impersonateUsersList, options, "Users with access to impersonate")
+		escalateUsersList := eathar.EscalateUsers(options)
+		eathar.ReportRBAC(escalateUsersList, options, "Users with access to escalate")
+		bindUsersList := eathar.BindUsers(options)
+		eathar.ReportRBAC(bindUsersList, options, "Users with access to bind")
+		validatingWebhookUsersList := eathar.ValidatingWebhookUsers(options)
+		eathar.ReportRBAC(validatingWebhookUsersList, options, "Users with access to create or modify validatingadmissionwebhookconfigurations")
+		mutatingWebhookUsersList := eathar.MutatingWebhookUsers(options)
+		eathar.ReportRBAC(mutatingWebhookUsersList, options, "Users with access to create or modify mutatingadmissionwebhookconfigurations")
+		wildcardUsersList := eathar.WildcardAccess(options)
+		eathar.ReportRBAC(wildcardUsersList, options, "Users with wildcard access to all resources")
+		satokenUsersList := eathar.CreateServiceAccountTokens(options)
+		eathar.ReportRBAC(satokenUsersList, options, "Users with create access to service account tokens")
+	},
+}
+
+func init() {
+	rbacCmd.AddCommand(allRBACCmd)
+
+}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -5,7 +5,6 @@ Copyright © 2022 Rory McCune <rorym@mccune.org.uk>
 package cmd
 
 import (
-	"github.com/raesene/eathar/pkg/eathar"
 	"github.com/spf13/cobra"
 )
 
@@ -13,25 +12,15 @@ import (
 var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Checks that provide general information about a cluster",
-	Long: `This command returns "interesting" information about a cluster.
-		You can run indivdual checks using subcommands.`,
+	Long: `These commands return general information about a cluster.
+	you can use the all command to run all the checks, or run each check individually`,
 	Run: func(cmd *cobra.Command, args []string) {
-		options := cmd.Flags()
-		imageListSlice := eathar.ImageList(options)
-		eathar.ReportImage(imageListSlice, options, "Image List")
+		//return help for info command
+		cmd.Help()
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(infoCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// infoCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/pss.go
+++ b/cmd/pss.go
@@ -5,46 +5,19 @@ Copyright © 2022 Rory McCune <rorym@mccune.org.uk>
 package cmd
 
 import (
-	"github.com/raesene/eathar/pkg/eathar"
 	"github.com/spf13/cobra"
 )
 
 // pssCmd represents the pss command
 var pssCmd = &cobra.Command{
 	Use:   "pss",
-	Short: "Runs all the PSS checks",
-	Long: `This command runs all the available Pod Security checks on the target cluster.
-	  You can individual checks by using the subcommands`,
+	Short: "Checks relating to Pod Security Standards",
+	Long: `These commands run Pod Security checks on the target cluster.
+	  you can use the all command to run all the checks, or run each check individually`,
 	Run: func(cmd *cobra.Command, args []string) {
-		options := cmd.Flags()
-		allowprivesccont := eathar.AllowPrivEsc(options)
-		eathar.ReportPSS(allowprivesccont, options, "Allow Privilege Escalation")
-		apparmor := eathar.Apparmor(options)
-		eathar.ReportPSS(apparmor, options, "Apparmor Disabled")
-		capadded := eathar.AddedCapabilities(options)
-		eathar.ReportPSS(capadded, options, "Added Capabilities")
-		capdropped := eathar.DroppedCapabilities(options)
-		eathar.ReportPSS(capdropped, options, "Dropped Capabilities")
-		hostipccont := eathar.Hostipc(options)
-		eathar.ReportPSS(hostipccont, options, "Host IPC")
-		hostnetcont := eathar.Hostnet(options)
-		eathar.ReportPSS(hostnetcont, options, "Host Network")
-		hostpath := eathar.HostPath(options)
-		eathar.ReportPSS(hostpath, options, "Host Path")
-		hostpidcont := eathar.Hostpid(options)
-		eathar.ReportPSS(hostpidcont, options, "Host PID")
-		hostports := eathar.HostPorts(options)
-		eathar.ReportPSS(hostports, options, "Host Ports")
-		hostprocesscont := eathar.HostProcess(options)
-		eathar.ReportPSS(hostprocesscont, options, "Host Process")
-		privcont := eathar.Privileged(options)
-		eathar.ReportPSS(privcont, options, "Privileged Container")
-		seccomp := eathar.Seccomp(options)
-		eathar.ReportPSS(seccomp, options, "Seccomp Disabled")
-		unmaskedproc := eathar.Procmount(options)
-		eathar.ReportPSS(unmaskedproc, options, "Unmasked Procmount")
-		sysctls := eathar.Sysctl(options)
-		eathar.ReportPSS(sysctls, options, "Unsafe Sysctl")
+		//return the help for the pss command
+		cmd.Help()
+
 	},
 }
 

--- a/cmd/rbac.go
+++ b/cmd/rbac.go
@@ -5,51 +5,22 @@ Copyright © 2022 Rory McCune <rorym@mccune.org.uk>
 package cmd
 
 import (
-	"github.com/raesene/eathar/pkg/eathar"
 	"github.com/spf13/cobra"
 )
 
 // rbacCmd represents the rbac command
 var rbacCmd = &cobra.Command{
 	Use:   "rbac",
-	Short: "Runs all the RBAC checks",
-	Long: `This runs all the RBAC commands, 
-	you can run each check individually if you wish, using the subcommands`,
+	Short: "Checks related to cluster RBAC",
+	Long: `This command runs RBAC checks on the target cluster., 
+	you can use the all command to run all the checks, or run each check individually`,
 	Run: func(cmd *cobra.Command, args []string) {
-		options := cmd.Flags()
-		clusterAdminRoleBindingList := eathar.GetClusterAdminUsers(options)
-		eathar.ReportRBAC(clusterAdminRoleBindingList, options, "Cluster Admin Users")
-		getSecretsUsersList := eathar.GetSecretsUsers(options)
-		eathar.ReportRBAC(getSecretsUsersList, options, "Users with access to secrets")
-		createPVUsersList := eathar.CreatePVUsers(options)
-		eathar.ReportRBAC(createPVUsersList, options, "Users with access to create persistent volumes")
-		impersonateUsersList := eathar.ImpersonateUsers(options)
-		eathar.ReportRBAC(impersonateUsersList, options, "Users with access to impersonate")
-		escalateUsersList := eathar.EscalateUsers(options)
-		eathar.ReportRBAC(escalateUsersList, options, "Users with access to escalate")
-		bindUsersList := eathar.BindUsers(options)
-		eathar.ReportRBAC(bindUsersList, options, "Users with access to bind")
-		validatingWebhookUsersList := eathar.ValidatingWebhookUsers(options)
-		eathar.ReportRBAC(validatingWebhookUsersList, options, "Users with access to create or modify validatingadmissionwebhookconfigurations")
-		mutatingWebhookUsersList := eathar.MutatingWebhookUsers(options)
-		eathar.ReportRBAC(mutatingWebhookUsersList, options, "Users with access to create or modify mutatingadmissionwebhookconfigurations")
-		wildcardUsersList := eathar.WildcardAccess(options)
-		eathar.ReportRBAC(wildcardUsersList, options, "Users with wildcard access to all resources")
-		satokenUsersList := eathar.CreateServiceAccountTokens(options)
-		eathar.ReportRBAC(satokenUsersList, options, "Users with create access to service account tokens")
+		//return help for RBAC command
+		cmd.Help()
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(rbacCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// rbacCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// rbacCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }


### PR DESCRIPTION
This changes the setup from the bare top level command running everything (unwieldy) to that just returning help, and adds an `all` command to each sub-category to replace that.